### PR TITLE
Module 'colorama' is added to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ dnspython
 tldextract
 lxml
 bs4
+colorama


### PR DESCRIPTION
After installation and running this project, I found that this script is using **colorama**  module in status.py file,
which is not installed by default. 
It showing error Module error 
```
Traceback (most recent call last):
  File "main.py", line 5, in <module>
    from utils.status import *
  File "C:\Users\~~\Eagle\utils\status.py", line 2, in <module>
    from colorama import Fore
ModuleNotFoundError: No module named 'colorama'
```
for above problem I added this module into requirement file